### PR TITLE
Fix argument mismatch when resetting the state.

### DIFF
--- a/sam2/sam2_camera_predictor.py
+++ b/sam2/sam2_camera_predictor.py
@@ -717,7 +717,7 @@ class SAM2CameraPredictor(SAM2Base):
     @torch.inference_mode()
     def reset_state(self):
         """Remove all input points or mask in all frames throughout the video."""
-        self._reset_tracking_results(self.condition_state)
+        self._reset_tracking_results()
         # Remove all object ids
         self.condition_state["obj_id_to_idx"].clear()
         self.condition_state["obj_idx_to_id"].clear()


### PR DESCRIPTION
Remove class variable `self.condition_state` from being passed to `_reset_tracking_result`, which has caused an error due to the mismatch in the expected number of positional arguments.